### PR TITLE
cpu-info: Fix compilation error

### DIFF
--- a/src/cpu_info.cpp
+++ b/src/cpu_info.cpp
@@ -22,7 +22,7 @@ extern "C" {
 #include "esmi_rmi.h"
 #include "esmi_cpuid_msr.h"
 #include "esmi_tsi.h"
-#include "esmi_mailbox_int.h"
+#include "esmi_mailbox_nda.h"
 }
 
 #define COMMAND_BOARD_ID    ("/sbin/fw_printenv -n board_id")


### PR DESCRIPTION
Fixes compilation error due to the use of internal apml library instead of NDA apml library.

Signed-off-by: Supreeth Venkatesh <supreeth.venkatesh@amd.com>