### PR TITLE
Fix popen return value check

### DIFF
--- a/src/cpu_info.cpp
+++ b/src/cpu_info.cpp
@@ -528,7 +528,7 @@ bool CpuInfo::getNumberOfCpu()
     {
        // Setup pipe for reading and execute to get u-boot environment
        pf = popen(COMMAND_NUM_OF_CPU,"r");
-       if(pf > 0)
+       if(!pf)
        {   // no error
           if (fgets(data, COMMAND_LEN , pf) != NULL)
           {


### PR DESCRIPTION
Fixes the error when trying to build on the latest OpenBMC:

```
| …/src/cpu_info.cpp: In member function 'bool CpuInfo::getNumberOfCpu()':
| …/src/cpu_info.cpp:530:14: error: ordered comparison of pointer with integer zero ('FILE*' and 'int')
|   530 |        if(pf > 0)
|       |           ~~~^~~
```

This change has not been tested.
