### PR TITLE
Remove polling of APML command

### DIFF
--- a/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
+++ b/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
@@ -12,5 +12,5 @@ SyslogIdentifier=cpu-info
 Type=simple
 
 [Install]
-WantedBy=multi-user.target
+#WantedBy=multi-user.target
 

--- a/src/cpu_info.cpp
+++ b/src/cpu_info.cpp
@@ -76,14 +76,6 @@ uint32_t edx;
 // Init CPU Information using OOB library
 void CpuInfo::collect_cpu_information(uint8_t soc_num)
 {
-    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-
-    while (ret != OOB_SUCCESS)
-    {
-        ret = esmi_get_processor_info(0, plat_info);
-        sleep(1);
-    }
-
     if (connect_apml_get_family_model_step(soc_num))
     {
         set_general_info();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@ uint8_t getSocketInfo()
     uint8_t cpuCount = 0;
     uint32_t boardId;
 
+    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
+
     std::unique_ptr<FILE, void (*)(FILE*)> pipe(
         popen("/sbin/fw_printenv -n board_id", "r"), [](FILE* f) {
             if (f)


### PR DESCRIPTION
 Remove polling of APML command to check if the APML is up as it is breaking the processor redfish URI without no response until APML is up.
 Prevent the cpu-info service from starting automatically at boot and it will started by the set-apml.sh script once APML is up.

