### PR TITLE
Remove APML command polling and decoding of PPIN value

### DIFF
--- a/src/cpu_info.cpp
+++ b/src/cpu_info.cpp
@@ -76,14 +76,6 @@ uint32_t edx;
 // Init CPU Information using OOB library
 void CpuInfo::collect_cpu_information(uint8_t soc_num)
 {
-    oob_status_t ret = OOB_MAILBOX_CMD_UNKNOWN;
-
-    while (ret != OOB_SUCCESS)
-    {
-        ret = esmi_get_processor_info(0, plat_info);
-        sleep(1);
-    }
-
     if (connect_apml_get_family_model_step(soc_num))
     {
         set_general_info();

--- a/src/cpu_info.cpp
+++ b/src/cpu_info.cpp
@@ -512,7 +512,11 @@ void CpuInfo::get_ppin_fuse(uint8_t soc_num)
     }
     else
     {
-        decode_PPIN(data);
+        id(data);
+        if(data != 0)
+        {
+            decode_PPIN(data);
+        }
     }
 }
 
@@ -648,8 +652,6 @@ void CpuInfo::decode_PPIN(uint64_t data)
     std::string markedlotstr;
     std::string datemonthlotstr;
     std::string serialnumstr;
-
-    id(data);
 
     sprintf(ppinstr, "0%lx", data);
     decode_lotstring(ppinstr, markedlotstr);


### PR DESCRIPTION
Remove polling of APML command to check if the
APML is up as it is breaking the processor redfish URI without no response until APML is up.

Decode the PPIN value if it returns a non zero valid value.
