### PR TITLE
Start the service when the APML communication is ready

### DIFF
--- a/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
+++ b/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
@@ -5,6 +5,7 @@ After=mapper-wait@-xyz-openbmc_project-inventory.service
 After=xyz.openbmc_project.Control.Host.Power_cap.service
 
 [Service]
+ExecStartPre=/bin/sh -c 'while [ ! -f /var/run/apml_comm_active ]; do sleep 1; done'
 ExecStart=/usr/bin/cpu-info
 Restart=always
 RestartSec=3


### PR DESCRIPTION
This commit adds an ExecStartPre command to the service configuration. The command uses a while loop to check for the existence of the /var/run/apml_comm_active file and waits until the file is present before proceeding. This ensures that the service starts only after the required communication file is active.

Tested fields: Verified on Congo UU platform.