### PR TITLE
Sleep 60 seconds after APML is up

### DIFF
--- a/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
+++ b/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
@@ -5,7 +5,7 @@ After=mapper-wait@-xyz-openbmc_project-inventory.service
 After=xyz.openbmc_project.Control.Host.Power_cap.service
 
 [Service]
-ExecStartPre=/bin/sh -c 'while [ ! -f /var/run/apml_comm_active ]; do sleep 1; done'
+ExecStartPre=/bin/sh -c 'while [ ! -f /var/run/apml_comm_active ]; do sleep 1; done; sleep 60'
 ExecStart=/usr/bin/cpu-info
 Restart=always
 RestartSec=3


### PR DESCRIPTION
Added a sleep command to ExecStartPre to wait
for 60 seconds after the /var/run/apml_comm_active file is detected. This ensures that the CPU information will be available when the service starts.