### PR TITLE
Fix: Add creation of P1 object path for CPU1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,12 +87,15 @@ int main()
     sdbusplus::server::manager_t inventory{bus,
                                            "/xyz/openbmc_project/inventory"};
     sdbusplus::server::manager_t manager0{bus, DBUS_P0_OBJECT_NAME};
-    CpuInfo cpuInfo{bus, DBUS_P0_OBJECT_NAME, eventP, 0};
+    CpuInfo cpuInfo0{bus, DBUS_P0_OBJECT_NAME, eventP, 0};
+
+    std::optional<sdbusplus::server::manager_t> manager1;
+    std::optional<CpuInfo> cpuInfo1;
 
     if (cpuCount == SOCKET_2)
     {
-        sdbusplus::server::manager_t managaer1{bus, DBUS_P1_OBJECT_NAME};
-        CpuInfo cpuInfo{bus, DBUS_P1_OBJECT_NAME, eventP, 1};
+        manager1.emplace(bus, DBUS_P1_OBJECT_NAME);
+        cpuInfo1.emplace(bus, DBUS_P1_OBJECT_NAME, eventP, 1);
     }
 
     try


### PR DESCRIPTION
Previously, the P1 object path was not being created, which caused issues when `cpuCount` was set to `SOCKET_2`. This fix introduces optional `manager1` and `cpuInfo1` instances that are initialized when the second socket is present, ensuring the P1 path is correctly set up.

Tested fields: Verified in Congo platform.