### PR TITLE
Replace hardcoded sleep with async retry

### DIFF
--- a/inc/cpu_info.hpp
+++ b/inc/cpu_info.hpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <thread>
 
 #define CPUID_Fn8000002 (0x80000002)
 #define CPUID_Fn8000003 (0x80000003)
@@ -61,7 +62,8 @@ struct EventDeleter
 };
 
 using EventPtr = std::unique_ptr<sd_event, EventDeleter>;
-using ProcessorPtr = sdbusplus::server::xyz::openbmc_project::inventory::item::Cpu;
+using ProcessorPtr =
+    sdbusplus::server::xyz::openbmc_project::inventory::item::Cpu;
 using Asset =
     sdbusplus::server::xyz::openbmc_project::inventory::decorator::Asset;
 
@@ -113,14 +115,18 @@ struct CpuInfo :
                             sd_journal_print(
                                 LOG_INFO,
                                 "cpu service started after bmc or host reboot... \n");
-                            collect_cpu_information(soc_num);
+                            std::thread([this, soc_num]() {
+                                collect_cpu_information(soc_num);
+                            }).detach();
                         }
                     }
                 }
             })
     {
         sd_journal_print(LOG_DEBUG, "cpu service start... \n");
-        collect_cpu_information(soc_num);
+        std::thread([this, soc_num]() {
+            collect_cpu_information(soc_num);
+        }).detach();
     }
     ~CpuInfo() {}
 

--- a/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
+++ b/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
@@ -2,13 +2,13 @@
 Description=CPU Information
 Wants=mapper-wait@-xyz-openbmc_project-inventory.service
 After=mapper-wait@-xyz-openbmc_project-inventory.service
-After=xyz.openbmc_project.Control.Host.Power_cap.service
+After=amd-host-mgr.service
 
 [Service]
-ExecStartPre=/bin/sh -c 'while [ ! -f /var/run/apml_comm_active ]; do sleep 1; done; sleep 60'
+ExecStartPre=/bin/sh -c 'while [ ! -f /var/run/apml_comm_active ]; do sleep 1; done'
 ExecStart=/usr/bin/cpu-info
 Restart=always
-RestartSec=3
+RestartSec=10
 SyslogIdentifier=cpu-info
 Type=simple
 

--- a/src/cpu_info.cpp
+++ b/src/cpu_info.cpp
@@ -29,7 +29,7 @@ extern "C"
 }
 
 #define COMMAND_LEN (3)
-#define MAX_RETRY 20
+#define MAX_RETRY 30
 
 #define CMD_BUFF_LEN 256
 #define FNAME_LEN 128
@@ -43,7 +43,7 @@ extern "C"
 #define EAX_MASK_MAGIC_1 0xf
 #define EAX_MASK_MAGIC_2 0xff
 #define EAX_MASK_MAGIC_3 0x10
-#define APML_SLEEP 10000
+#define APML_SLEEP 10
 
 // PPIN logic
 #define LOWER_PINBITS 8
@@ -141,21 +141,42 @@ bool CpuInfo::connect_apml_get_family_model_step(uint8_t soc_num)
     edx = 0;
     eax = EAX_VAL;
     ecx = 0;
+
+    boost::asio::io_context io;
+    boost::asio::steady_timer timer(io);
+
     try
     {
-        while (retry < MAX_RETRY)
-        {
-            ret = esmi_oob_cpuid(soc_num, core_id, &eax, &ebx, &ecx, &edx);
-            if (ret != 0)
+        std::function<void(const boost::system::error_code&)> retry_handler;
+        retry_handler = [&](const boost::system::error_code& ec) {
+            if (ec)
             {
-                usleep(APML_SLEEP);
+                return;
+            }
+
+            ret = esmi_oob_cpuid(soc_num, core_id, &eax, &ebx, &ecx, &edx);
+            if (ret != 0 && retry < MAX_RETRY)
+            {
                 retry++;
+                sd_journal_print(
+                    LOG_ERR,
+                    "Retry count %d: Failed to read the CPU info from APML\n",
+                    retry);
+
+                timer.expires_after(std::chrono::seconds(APML_SLEEP));
+                timer.async_wait(retry_handler); // recurse asynchronously
             }
             else
             {
-                break;
+                io.stop();
             }
-        } // end of retry
+        };
+
+        // Start first attempt immediately
+        timer.expires_after(std::chrono::seconds(0));
+        timer.async_wait(retry_handler);
+
+        io.run();
 
         std::string processor_presence =
             (soc_num == 0) ? P0_Present : P1_Present;
@@ -513,7 +534,7 @@ void CpuInfo::get_ppin_fuse(uint8_t soc_num)
     else
     {
         id(data);
-        if(data != 0)
+        if (data != 0)
         {
             decode_PPIN(data);
         }


### PR DESCRIPTION
- Removed the fixed 60-second sleep from the systemd service file to avoid unnecessary delays or premature startup failures.
- Introduced asynchronous retry logic using Boost.Asio to poll for APML readiness, allowing dynamic wait times based on actual hardware response.
- Increased MAX_RETRY to 30 and reduced APML_SLEEP interval to 10 seconds for finer-grained retry control.
- Made `collect_cpu_information()` asynchronous by running it in detached threads to prevent blocking systemd and busctl interactions.
- Changed service dependency from Host Power Cap to amd-host-mgr.service
- Increased RestartSec from 3 to 10 seconds to allow more time for recovery in case of failures.

Testef fields: Verified in Congo platform