### PR TITLE
Fix ExecStartPre APML check for updated filenames

### DIFF
--- a/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
+++ b/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
@@ -5,7 +5,13 @@ After=mapper-wait@-xyz-openbmc_project-inventory.service
 After=amd-host-mgr.service
 
 [Service]
-ExecStartPre=/bin/sh -c 'while [ ! -f /var/run/apml_comm_active ]; do sleep 1; done'
+ExecStartPre=/bin/sh -c '\
+if [ -e /sys/bus/i3c/devices/14c25000.i3c5 ]; then \
+  while [ ! -f /var/run/apml_comm_active_0 ] && [ ! -f /var/run/apml_comm_active_1 ]; do sleep 1; done; \
+else \
+  while [ ! -f /var/run/apml_comm_active_0 ]; do sleep 1; done; \
+fi'
+
 ExecStart=/usr/bin/cpu-info
 Restart=always
 RestartSec=10


### PR DESCRIPTION
Updated the service pre-start logic to correctly handle both 1P and 2P systems using the new APML communication flag filenames.
- In 2P systems, wait for both apml_comm_active_0 and _1
- In 1P systems, wait for apml_comm_active_0 only

Tested fields : Verified in Congo and Morocco system.