### PR TITLE
cpu-info: serialize D-Bus writes to fix coredump

### DIFF
--- a/inc/cpu_info.hpp
+++ b/inc/cpu_info.hpp
@@ -1,4 +1,6 @@
 #include <fcntl.h>
+#include <sys/eventfd.h>
+#include <systemd/sd-event.h>
 #include <unistd.h>
 
 #include <phosphor-logging/elog-errors.hpp>
@@ -10,9 +12,12 @@
 #include <xyz/openbmc_project/State/Host/server.hpp>
 
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <map>
+#include <mutex>
+#include <queue>
 #include <sstream>
 #include <thread>
 
@@ -62,6 +67,50 @@ struct EventDeleter
 };
 
 using EventPtr = std::unique_ptr<sd_event, EventDeleter>;
+
+/**
+ * @brief Marshals work onto the sd_event (main) thread.
+ *
+ * An sd_bus connection is thread-compatible, not thread-safe: it may be used
+ * from multiple threads only with external locking, and a single connection
+ * must never be accessed concurrently (see openbmc/sdbusplus#28). Rather than
+ * lock around every call, this daemon keeps all bus access on the one thread
+ * that owns and dispatches the connection via the sd_event loop. Worker threads
+ * that perform the slow APML/OOB register reads post their D-Bus setter calls
+ * (which emit PropertiesChanged, etc.) here; the tasks are then executed on the
+ * event-loop thread when it wakes on the eventfd.
+ */
+class EventLoopDispatcher
+{
+  public:
+    EventLoopDispatcher() = default;
+    ~EventLoopDispatcher();
+
+    EventLoopDispatcher(const EventLoopDispatcher&) = delete;
+    EventLoopDispatcher& operator=(const EventLoopDispatcher&) = delete;
+
+    /**
+     * @brief Create the eventfd and register it with the sd_event loop.
+     *        Must be called once on the event-loop thread before use.
+     * @return 0 on success, negative errno on failure.
+     */
+    int init(sd_event* event);
+
+    /**
+     * @brief Enqueue a task to run on the event-loop thread. Thread-safe.
+     */
+    void post(std::function<void()> task);
+
+  private:
+    static int onEvent(sd_event_source* source, int fd, uint32_t revents,
+                       void* userdata);
+
+    int eventFd = -1;
+    sd_event_source* source = nullptr;
+    std::mutex mutex;
+    std::queue<std::function<void()>> tasks;
+};
+
 using ProcessorPtr =
     sdbusplus::server::xyz::openbmc_project::inventory::item::Cpu;
 using Asset =
@@ -82,12 +131,12 @@ struct CpuInfo :
         cpuinfoDataHolderObj->getInstance();
 
     CpuInfo(sdbusplus::bus::bus& bus, const std::string& path, EventPtr&,
-            uint8_t soc_num) :
+            uint8_t soc_num, EventLoopDispatcher* dispatcher) :
         sdbusplus::server::object_t<
             ProcessorPtr, Asset,
             sdbusplus::xyz::openbmc_project::Inventory::server::Item>(
             bus, path.c_str()),
-        bus(bus), soc_num(soc_num),
+        bus(bus), soc_num(soc_num), dispatcher(dispatcher),
         propertiesChangedSignalCurrentHostState(
             bus,
             sdbusplus::bus::match::rules::type::signal() +
@@ -133,8 +182,20 @@ struct CpuInfo :
   private:
     sdbusplus::bus::bus& bus;
     uint8_t soc_num;
+    EventLoopDispatcher* dispatcher;
     sdbusplus::bus::match_t propertiesChangedSignalCurrentHostState;
     std::string get_interface(uint8_t enum_val);
+
+    // Run a D-Bus property setter (or any bus access) on the event-loop
+    // thread. Called from worker threads to keep all sd-bus access on a
+    // single thread, as sd-bus requires.
+    void postToBus(std::function<void()> task)
+    {
+        if (dispatcher)
+        {
+            dispatcher->post(std::move(task));
+        }
+    }
 
     // oob-lib functions
     void collect_cpu_information(uint8_t);

--- a/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
+++ b/service_files/xyz.openbmc_project.Inventory.Item.Cpu_info.service
@@ -5,7 +5,13 @@ After=mapper-wait@-xyz-openbmc_project-inventory.service
 After=amd-host-mgr.service
 
 [Service]
-ExecStartPre=/bin/sh -c '\
+# The APML-wait below can be interrupted by SIGTERM when the unit is stopped
+# or replaced before APML is ready (e.g. BMC reboot/firmware update while the
+# host is still off). Trap TERM to exit 0 so this pre-start shell does not make
+# systemd mark the unit 'failed' (a spurious "exited unsuccessfully" event-log
+# entry). The cpu-info daemon itself handles SIGTERM and exits 0, so no
+# SuccessExitStatus override is needed.
+ExecStartPre=/bin/sh -c 'trap "exit 0" TERM; \
 if [ -e /sys/bus/i3c/devices/14c25000.i3c5 ]; then \
   while [ ! -f /var/run/apml_comm_active_0 ] && [ ! -f /var/run/apml_comm_active_1 ]; do sleep 1; done; \
 else \
@@ -15,9 +21,11 @@ fi'
 ExecStart=/usr/bin/cpu-info
 Restart=always
 RestartSec=10
+# No [Install]/WantedBy: cpu-info must NOT auto-start at BMC boot. Its lifecycle
+# is owned by amd-host-mgr's state managers, which start it on host power-on
+# once APML/PMFW is ready (s0-state-mgr) and stop it on host power-off
+# (s5-state-mgr). Auto-starting at boot with the host off would block in
+# ExecStartPre waiting for APML and churn on Restart=always.
 SyslogIdentifier=cpu-info
 Type=simple
-
-[Install]
-WantedBy=multi-user.target
 

--- a/src/cpu_info.cpp
+++ b/src/cpu_info.cpp
@@ -2,6 +2,9 @@
 
 #include <linux/ioctl.h>
 #include <linux/types.h>
+#include <sys/epoll.h>
+
+#include <cerrno>
 
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
@@ -65,6 +68,97 @@ const std::string P0_Present = "P0_PRESENT_L";
 const std::string P1_Present = "P1_PRESENT_L";
 
 CpuInfoDataHolder* CpuInfoDataHolder::instance = 0;
+
+EventLoopDispatcher::~EventLoopDispatcher()
+{
+    if (source)
+    {
+        source = sd_event_source_unref(source);
+    }
+    if (eventFd >= 0)
+    {
+        close(eventFd);
+        eventFd = -1;
+    }
+}
+
+int EventLoopDispatcher::init(sd_event* event)
+{
+    eventFd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    if (eventFd < 0)
+    {
+        sd_journal_print(LOG_ERR, "Failed to create dispatcher eventfd: %d\n",
+                         errno);
+        return -errno;
+    }
+
+    int ret = sd_event_add_io(event, &source, eventFd, EPOLLIN,
+                              &EventLoopDispatcher::onEvent, this);
+    if (ret < 0)
+    {
+        sd_journal_print(LOG_ERR,
+                         "Failed to register dispatcher eventfd source: %d\n",
+                         ret);
+        close(eventFd);
+        eventFd = -1;
+        return ret;
+    }
+
+    return 0;
+}
+
+void EventLoopDispatcher::post(std::function<void()> task)
+{
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        tasks.push(std::move(task));
+    }
+
+    // Wake up the event loop. eventfd is a running counter; a single write
+    // is sufficient to make the loop dispatch onEvent, which drains all
+    // queued tasks.
+    uint64_t value = 1;
+    if (eventFd >= 0)
+    {
+        ssize_t rc = write(eventFd, &value, sizeof(value));
+        if (rc != sizeof(value))
+        {
+            sd_journal_print(LOG_ERR,
+                             "Failed to signal dispatcher eventfd: %zd\n", rc);
+        }
+    }
+}
+
+int EventLoopDispatcher::onEvent(sd_event_source* /*source*/, int fd,
+                                 uint32_t /*revents*/, void* userdata)
+{
+    auto* self = static_cast<EventLoopDispatcher*>(userdata);
+
+    // Clear the eventfd counter.
+    uint64_t value = 0;
+    ssize_t rc = read(fd, &value, sizeof(value));
+    (void)rc;
+
+    // Move the queued tasks out under the lock, then run them without holding
+    // it (a task may itself post more work).
+    std::queue<std::function<void()>> pending;
+    {
+        std::lock_guard<std::mutex> lock(self->mutex);
+        std::swap(pending, self->tasks);
+    }
+
+    while (!pending.empty())
+    {
+        auto& task = pending.front();
+        if (task)
+        {
+            task();
+        }
+        pending.pop();
+    }
+
+    return 0;
+}
 
 uint8_t p0_info = 0;
 uint8_t p1_info = 1;
@@ -163,14 +257,14 @@ bool CpuInfo::connect_apml_get_family_model_step(uint8_t soc_num)
         if (cpuPresence == 1)
         {
             // set false -Absent if GPIO value is high
-            present(false);
+            postToBus([this]() { present(false); });
             sd_journal_print(LOG_INFO, "Warning : %d CPU is absent \n",
                              soc_num);
             return false;
         }
         else
         {
-            present(true);
+            postToBus([this]() { present(true); });
         }
 
         if (ret != 0)
@@ -181,32 +275,32 @@ bool CpuInfo::connect_apml_get_family_model_step(uint8_t soc_num)
         else
         {
             ext_family = ((eax >> EAX_DATA_LEN_4) & EAX_MASK_MAGIC_2);
-            effectiveFamily(ext_family);
+            postToBus([this, ext_family]() { effectiveFamily(ext_family); });
 
             char cpuid[CMD_BUFF_LEN] = {0};
             family_id = ((eax >> EAX_DATA_LEN_2) & EAX_MASK_MAGIC_1) +
                         ext_family;
             sprintf(cpuid, "%x (%d)", family_id, family_id);
             std::string family_str(cpuid);
-            family(family_str);
+            postToBus([this, family_str]() { family(family_str); });
 
             ext_model = ((eax >> EAX_DATA_LEN_3) & EAX_MASK_MAGIC_1);
-            effectiveModel(ext_model);
+            postToBus([this, ext_model]() { effectiveModel(ext_model); });
 
             char cpuid_m[CMD_BUFF_LEN] = {0};
             model_id = ext_model * EAX_MASK_MAGIC_3 +
                        ((eax >> EAX_DATA_LEN_1) & EAX_MASK_MAGIC_1);
             sprintf(cpuid_m, "%x (%d)", model_id, model_id);
             std::string model_str(cpuid);
-            model(model_str);
+            postToBus([this, model_str]() { model(model_str); });
 
             step_id = eax & EAX_MASK_MAGIC_1;
-            step(step_id);
+            postToBus([this, step_id]() { step(step_id); });
 
             char cpuid_soc[CMD_BUFF_LEN] = {0};
             sprintf(cpuid_soc, "%d", soc_num);
             std::string socket_str(cpuid_soc);
-            socket(socket_str);
+            postToBus([this, socket_str]() { socket(socket_str); });
 
             return true;
         }
@@ -370,8 +464,9 @@ void CpuInfo::get_opn(uint8_t soc_num)
     std::string opn_str(OpnChar);
     sd_journal_print(LOG_INFO, "OPN string # %s \n", opn_str.c_str());
 
-    // set the value in DBUS
-    partNumber(opn_str);
+    // set the value in DBUS (on the event-loop thread; a bus connection must
+    // not be accessed concurrently from multiple threads)
+    postToBus([this, opn_str]() { partNumber(opn_str); });
 }
 
 // Read register thru apml lib
@@ -427,8 +522,10 @@ u_int8_t CpuInfo::get_reg_offset_conv(uint32_t reg, uint32_t offset,
 
 void CpuInfo::set_general_info()
 {
-    manufacturer("AMD");
-    vendorId("AuthenticAMD");
+    postToBus([this]() {
+        manufacturer("AMD");
+        vendorId("AuthenticAMD");
+    });
 }
 
 // Get processor threads per Core and Socket
@@ -447,7 +544,9 @@ void CpuInfo::get_threads_per_core_and_soc(uint8_t soc_num)
         }
         else
         {
-            threadCount(threads_per_soc);
+            postToBus([this, threads_per_soc]() {
+                threadCount(threads_per_soc);
+            });
             isthreadcall_pass = true;
         }
         usleep(APML_SLEEP);
@@ -463,7 +562,7 @@ void CpuInfo::get_threads_per_core_and_soc(uint8_t soc_num)
             if (isthreadcall_pass)
             {
                 uint32_t TotalCores = threads_per_soc / threads_per_core;
-                coreCount(TotalCores);
+                postToBus([this, TotalCores]() { coreCount(TotalCores); });
             }
         }
     }
@@ -494,7 +593,7 @@ void CpuInfo::get_cpu_base_freq(uint8_t soc_num)
         return;
     }
 
-    maxSpeedInMhz(buffer);
+    postToBus([this, buffer]() { maxSpeedInMhz(buffer); });
 }
 
 // Get PPIN then we need to Decode to get Serial Number
@@ -510,7 +609,7 @@ void CpuInfo::get_ppin_fuse(uint8_t soc_num)
     }
     else
     {
-        id(data);
+        postToBus([this, data]() { id(data); });
         if(data != 0)
         {
             decode_PPIN(data);
@@ -531,7 +630,7 @@ void CpuInfo::get_microcode_rev(uint8_t soc_num)
             return;
         }
         sd_journal_print(LOG_INFO, "|ucode revision  | 0x%-32x |\n", ucode);
-        microcode(ucode);
+        postToBus([this, ucode]() { microcode(ucode); });
     }
     catch (std::exception& e)
     {
@@ -662,7 +761,7 @@ void CpuInfo::decode_PPIN(uint64_t data)
     // serial Number = lotstring + month + year + devnum
     serialnumstr = markedlotstr + datemonthlotstr;
 
-    serialNumber(serialnumstr.c_str());
+    postToBus([this, serialnumstr]() { serialNumber(serialnumstr); });
 
     return;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,6 @@
+#include <pthread.h>
+
+#include <csignal>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -64,6 +67,19 @@ int main()
     phosphor::logging::log<phosphor::logging::level::INFO>(
         "Start cpu info service...");
 
+    // Block SIGTERM/SIGINT in this (and inherited worker) thread(s) so they are
+    // delivered synchronously to the sd_event loop instead of terminating the
+    // process via the default disposition. This must happen before any worker
+    // threads are spawned so they inherit the mask.
+    sigset_t signalMask;
+    sigemptyset(&signalMask);
+    sigaddset(&signalMask, SIGTERM);
+    sigaddset(&signalMask, SIGINT);
+    if (pthread_sigmask(SIG_BLOCK, &signalMask, nullptr) != 0)
+    {
+        sd_journal_print(LOG_ERR, "Failed to block SIGTERM/SIGINT\n");
+    }
+
     uint8_t cpuCount = getSocketInfo();
 
     sd_event* event = nullptr;
@@ -77,13 +93,32 @@ int main()
     EventPtr eventP{event};
     event = nullptr;
 
+    // Dispatcher used by worker threads to marshal all D-Bus setter calls back
+    // onto this (the event-loop) thread; a bus connection must not be
+    // accessed concurrently from multiple threads.
+    EventLoopDispatcher dispatcher;
+    ret = dispatcher.init(eventP.get());
+    if (ret < 0)
+    {
+        sd_journal_print(LOG_ERR, "Failed to init event loop dispatcher %d\n",
+                         ret);
+        return ret;
+    }
+
+    // Exit the event loop cleanly (return 0) on SIGTERM/SIGINT. A NULL handler
+    // makes sd-event call sd_event_exit() with code 0, so a commanded stop
+    // (e.g. s5-state-mgr on host power-off, or BMC reboot) is a clean shutdown
+    // rather than a signal-kill that systemd would report as a failure.
+    (void)sd_event_add_signal(eventP.get(), nullptr, SIGTERM, nullptr, nullptr);
+    (void)sd_event_add_signal(eventP.get(), nullptr, SIGINT, nullptr, nullptr);
+
     sdbusplus::bus::bus bus = sdbusplus::bus::new_default();
     bus.request_name(DBUS_SERVICE_NAME);
 
     sdbusplus::server::manager_t inventory{bus,
                                            "/xyz/openbmc_project/inventory"};
     sdbusplus::server::manager_t manager0{bus, DBUS_P0_OBJECT_NAME};
-    CpuInfo cpuInfo0{bus, DBUS_P0_OBJECT_NAME, eventP, 0};
+    CpuInfo cpuInfo0{bus, DBUS_P0_OBJECT_NAME, eventP, 0, &dispatcher};
 
     std::optional<sdbusplus::server::manager_t> manager1;
     std::optional<CpuInfo> cpuInfo1;
@@ -91,7 +126,7 @@ int main()
     if (cpuCount == SOCKET_2)
     {
         manager1.emplace(bus, DBUS_P1_OBJECT_NAME);
-        cpuInfo1.emplace(bus, DBUS_P1_OBJECT_NAME, eventP, 1);
+        cpuInfo1.emplace(bus, DBUS_P1_OBJECT_NAME, eventP, 1, &dispatcher);
     }
 
     try


### PR DESCRIPTION
Route all sdbusplus property setters through an eventfd-based dispatcher so bus access happens only on the sd_event thread (sd-bus isn't thread-safe). Also trap SIGTERM in ExecStartPre + SuccessExitStatus=SIGTERM to avoid a spurious service-failure log.

Tested: Nigeria